### PR TITLE
Android fix camera release

### DIFF
--- a/src/Android_Unity_Player_Source/AndroidStudioProj/UnityARPlayer/src/main/java/org/artoolkit/ar/unity/CameraHandler.java
+++ b/src/Android_Unity_Player_Source/AndroidStudioProj/UnityARPlayer/src/main/java/org/artoolkit/ar/unity/CameraHandler.java
@@ -1,0 +1,9 @@
+package org.artoolkit.ar.unity;
+
+/**
+ * Created by justin on 9/29/17.
+ */
+
+public class CameraHandler {
+
+}

--- a/src/Android_Unity_Player_Source/AndroidStudioProj/UnityARPlayer/src/main/java/org/artoolkit/ar/unity/CameraHandler.java
+++ b/src/Android_Unity_Player_Source/AndroidStudioProj/UnityARPlayer/src/main/java/org/artoolkit/ar/unity/CameraHandler.java
@@ -1,9 +1,0 @@
-package org.artoolkit.ar.unity;
-
-/**
- * Created by justin on 9/29/17.
- */
-
-public class CameraHandler {
-
-}

--- a/src/Android_Unity_Player_Source/AndroidStudioProj/UnityARPlayer/src/main/java/org/artoolkit/ar/unity/CameraHolder.java
+++ b/src/Android_Unity_Player_Source/AndroidStudioProj/UnityARPlayer/src/main/java/org/artoolkit/ar/unity/CameraHolder.java
@@ -160,7 +160,6 @@ public class CameraHolder {
     public void CloseCamera()
     {
         if(mCamera != null) {
-            StopCapture();
             mCamera.release();
             mCamera = null;
 

--- a/src/Android_Unity_Player_Source/AndroidStudioProj/UnityARPlayer/src/main/java/org/artoolkit/ar/unity/CameraHolderNoThread.java
+++ b/src/Android_Unity_Player_Source/AndroidStudioProj/UnityARPlayer/src/main/java/org/artoolkit/ar/unity/CameraHolderNoThread.java
@@ -73,8 +73,7 @@ public class CameraHolderNoThread {
     public void OpenCamera() {
 
         if(mCamera != null) {
-            mCamera.release();
-            mCamera = null;
+            return;
         }
 
         // get camera ID
@@ -141,6 +140,7 @@ public class CameraHolderNoThread {
         if(mCamera != null) {
             try {
                 mCamera.stopPreview();
+                mCamera.setPreviewCallback(null); // <-- NEVER FORGET TO DO THIS AFTER STOP PREVIEW
 
                 mState = CameraHolderState.Idle;
                 Log.i(TAG, "Stop Capture Success");
@@ -213,92 +213,5 @@ public class CameraHolderNoThread {
             }
         }
         return camera_id;
-    }
-
-    // --------------------------------------------------
-    // Camera Holder Interactives
-    // --------------------------------------------------
-    public static void CommandOpenCamera() {
-        if (CameraHolderNoThread.Instance != null) {
-            CameraHolderNoThread.Instance.OpenCamera();
-        }
-        else {
-            Log.i(TAG, "CommandOpenCamera() CameraHolderNoThread.Instance was null");
-        }
-    }
-
-    public static void CommandCloseCamera() {
-        if (CameraHolderNoThread.Instance != null) {
-            CameraHolderNoThread.Instance.CloseCamera();
-        }
-        else {
-            Log.i(TAG, "CommandCloseCamera() CameraHolderNoThread.Instance was null");
-        }
-    }
-
-    public static void CommandStartCapture() {
-        if (CameraHolderNoThread.Instance != null) {
-            CameraHolderNoThread.Instance.StartCapture();
-        }
-        else {
-            Log.i(TAG, "CommandStartCapture() CameraHolderNoThread.Instance was null");
-        }
-
-    }
-
-    public static void CommandStopCapture() {
-        if (CameraHolderNoThread.Instance != null) {
-            CameraHolderNoThread.Instance.StopCapture();
-        }
-        else {
-            Log.i(TAG, "CommandStopCapture() CameraHolderNoThread.Instance was null");
-        }
-    }
-
-    public static void ConfigCameraResoulution(int w, int h)
-    {
-        if (CameraHolderNoThread.Instance != null) {
-            CameraHolderNoThread.Instance.mConfigW = w;
-            CameraHolderNoThread.Instance.mConfigH = h;
-            Log.i(TAG, "Set Camera Resolution : " + w + " : " + h);
-        }
-    }
-
-    public static void ApplyConfig()
-    {
-        if (CameraHolderNoThread.Instance != null) {
-            CommandCloseCamera();
-            CommandOpenCamera();
-        }
-    }
-
-    public static Boolean IsCameraOpened()
-    {
-        if (CameraHolderNoThread.Instance != null) {
-            return CameraHolderNoThread.Instance.mState != CameraHolderState.Closed;
-        }
-        return false;
-    }
-
-    public static Boolean IsCameraCapturing()
-    {
-        if (CameraHolderNoThread.Instance != null) {
-            return CameraHolderNoThread.Instance.mState == CameraHolderState.Capturing;
-        }
-        return false;
-    }
-
-    public static void ReminderCapturing(Boolean v)
-    {
-        if (CameraHolderNoThread.Instance != null) {
-            CameraHolderNoThread.Instance.mReminderCapturing = v;
-        }
-    }
-
-    public static Boolean IsReminderCapturing(){
-        if (CameraHolderNoThread.Instance != null) {
-            return CameraHolderNoThread.Instance.mReminderCapturing;
-        }
-        return false;
     }
 }

--- a/src/Android_Unity_Player_Source/AndroidStudioProj/UnityARPlayer/src/main/java/org/artoolkit/ar/unity/CameraHolderNoThread.java
+++ b/src/Android_Unity_Player_Source/AndroidStudioProj/UnityARPlayer/src/main/java/org/artoolkit/ar/unity/CameraHolderNoThread.java
@@ -29,8 +29,11 @@ public class CameraHolderNoThread {
         Capturing
     }
 
+    protected final static String TAG = "CameraHolderNoThread";
+
     // provide static for call function from unity3d
     public static CameraHolderNoThread Instance = null;
+
     // --------------------------------------------------
     // Message ID
     // --------------------------------------------------
@@ -40,7 +43,7 @@ public class CameraHolderNoThread {
     // camera variable
     // --------------------------------------------------
     public SurfaceTexture mHolderTexture;
-    private Camera mCamera;
+    private Camera mCamera = null;
     private int mWidth = 0;
     private int mHeight = 0;
     private boolean mCameraIsFrontFacing = false;
@@ -68,18 +71,20 @@ public class CameraHolderNoThread {
     }
 
     public void OpenCamera() {
+
         if(mCamera != null) {
-            return;
+            mCamera.release();
+            mCamera = null;
         }
 
         // get camera ID
         mCameraIndex = findFacingCameraId(FaceBack);
         try {
             mCamera = Camera.open(mCameraIndex); // attempt to get a Camera instance
-            Log.i("CameraHolder", "Open Camera Success");
+            Log.i(TAG, "Open Camera Success");
         }
-        catch (Exception e){
-            Log.e("CameraHolder", "ERROR OPENING CAMERA");
+        catch (Exception e) {
+            Log.e(TAG, "Error opening camera with message: " + e.getMessage());
         }
 
         mHolderTexture = new SurfaceTexture(49);
@@ -87,7 +92,7 @@ public class CameraHolderNoThread {
             mCamera.setPreviewTexture(mHolderTexture);
             mCamera.setPreviewCallback(mPreviewCallback);
 
-            Log.i("CameraHolder", "Set Camera Preview Callback");
+            Log.i(TAG, "Set Camera Preview Callback");
         } catch (IOException e) {
             e.printStackTrace();
         }
@@ -98,13 +103,25 @@ public class CameraHolderNoThread {
     public void CloseCamera()
     {
         if(mCamera != null) {
-            StopCapture();
-            mHolderTexture.release();
-            mHolderTexture = null;
-            mCamera.release();
-            mCamera = null;
+
+            try {
+                mHolderTexture.release();
+                mHolderTexture = null;
+            }
+            catch(Exception e) {
+                Log.e(TAG, "Could not release holder texture with message: " + e.getMessage());
+            }
+
+            try {
+                mCamera.release();
+                mCamera = null;
+            }
+            catch(Exception e) {
+                Log.e(TAG, "Could not release camera with message: " + e.getMessage());
+            }
+
             mState = CameraHolderState.Closed;
-            Log.i("CameraHolder", "Close Camera Success");
+            Log.i(TAG, "Close Camera Success");
         }
     }
 
@@ -115,22 +132,26 @@ public class CameraHolderNoThread {
             mCamera.startPreview();
 
             mState = CameraHolderState.Capturing;
-            Log.i("CameraHolder", "Start Capture Success");
+            Log.i(TAG, "Start Capture Success");
         }
     }
 
     public void StopCapture()
     {
         if(mCamera != null) {
-            mCamera.stopPreview();
+            try {
+                mCamera.stopPreview();
 
-            mState = CameraHolderState.Idle;
-            Log.i("CameraHolder", "Stop Capture Success");
+                mState = CameraHolderState.Idle;
+                Log.i(TAG, "Stop Capture Success");
+            }
+            catch(Exception e) {
+                Log.e(TAG, "Could not stop capture with message: " + e.getMessage());
+            }
         }
     }
 
-    public void DestroyCamera()
-    {
+    public void DestroyCamera() {
         mState = CameraHolderState.Closed;
     }
 
@@ -148,7 +169,7 @@ public class CameraHolderNoThread {
         mWidth = params.getPreviewSize().width;;
         mHeight = params.getPreviewSize().height;;
         mCameraIsFrontFacing = false;
-        Log.i("CameraHolder", "Set Config Camera");
+        Log.i(TAG, "Set Config Camera");
     }
 
     // --------------------------------------------------
@@ -170,6 +191,7 @@ public class CameraHolderNoThread {
             return true;
         } else {
             // no camera on this device
+            Log.i(TAG, "No camera");
             return false;
         }
     }
@@ -200,11 +222,17 @@ public class CameraHolderNoThread {
         if (CameraHolderNoThread.Instance != null) {
             CameraHolderNoThread.Instance.OpenCamera();
         }
+        else {
+            Log.i(TAG, "CommandOpenCamera() CameraHolderNoThread.Instance was null");
+        }
     }
 
     public static void CommandCloseCamera() {
         if (CameraHolderNoThread.Instance != null) {
             CameraHolderNoThread.Instance.CloseCamera();
+        }
+        else {
+            Log.i(TAG, "CommandCloseCamera() CameraHolderNoThread.Instance was null");
         }
     }
 
@@ -212,11 +240,18 @@ public class CameraHolderNoThread {
         if (CameraHolderNoThread.Instance != null) {
             CameraHolderNoThread.Instance.StartCapture();
         }
+        else {
+            Log.i(TAG, "CommandStartCapture() CameraHolderNoThread.Instance was null");
+        }
+
     }
 
     public static void CommandStopCapture() {
         if (CameraHolderNoThread.Instance != null) {
             CameraHolderNoThread.Instance.StopCapture();
+        }
+        else {
+            Log.i(TAG, "CommandStopCapture() CameraHolderNoThread.Instance was null");
         }
     }
 
@@ -225,7 +260,7 @@ public class CameraHolderNoThread {
         if (CameraHolderNoThread.Instance != null) {
             CameraHolderNoThread.Instance.mConfigW = w;
             CameraHolderNoThread.Instance.mConfigH = h;
-            Log.i("CameraHolder", "Set Camera Resolution : " + w + " : " + h);
+            Log.i(TAG, "Set Camera Resolution : " + w + " : " + h);
         }
     }
 

--- a/src/Android_Unity_Player_Source/AndroidStudioProj/UnityARPlayer/src/main/java/org/artoolkit/ar/unity/UnityARPlayerActivity.java
+++ b/src/Android_Unity_Player_Source/AndroidStudioProj/UnityARPlayer/src/main/java/org/artoolkit/ar/unity/UnityARPlayerActivity.java
@@ -78,7 +78,7 @@ public class UnityARPlayerActivity extends UnityPlayerActivity {
     protected final static int PERMISSION_REQUEST_CAMERA = 77;
 
     protected final static String TAG = "UnityARPlayerActivity";
-    private CameraHolder _holder;
+    private CameraHolderNoThread _holder;
 
     @SuppressWarnings("unused")
     public void OpenCamera()  {
@@ -154,135 +154,11 @@ public class UnityARPlayerActivity extends UnityPlayerActivity {
 
         super.onCreate(savedInstanceState);
 
-        //_holder = new CameraHolderNoThread();
-        _holder = new CameraHolder();
+        _holder = new CameraHolderNoThread();
 
         // This needs to be done just only the very first time the application is run,
         // or whenever a new preference is added (e.g. after an application upgrade).
         int resID = getResources().getIdentifier("preferences", "xml", getPackageName());
         PreferenceManager.setDefaultValues(this, resID, false);
     }
-
-    @Override
-    protected void onDestroy() {
-        super.onDestroy();
-
-        CameraHolderNoThread.CommandStopCapture();
-        CameraHolderNoThread.CommandCloseCamera();
-        CameraHolderNoThread.Instance.DestroyCamera();
-        getWindow().clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
-    }
 }
-
-/*
-// FOR REFERENCE, ORIGINAL UNITY PLAYER ACTIVITY (UnityPlayerNativeActivity is now obsolete)
-
-package com.companyname.product;
-
-import com.unity3d.player.*;
-import android.app.Activity;
-import android.content.Intent;
-import android.content.res.Configuration;
-import android.graphics.PixelFormat;
-import android.os.Bundle;
-import android.view.KeyEvent;
-import android.view.MotionEvent;
-import android.view.View;
-import android.view.Window;
-import android.view.WindowManager;
-
-public class UnityPlayerActivity extends Activity
-{
-    protected UnityPlayer mUnityPlayer; // don't change the name of this variable; referenced from native code
-
-    // Setup activity layout
-    @Override protected void onCreate (Bundle savedInstanceState)
-    {
-        requestWindowFeature(Window.FEATURE_NO_TITLE);
-        super.onCreate(savedInstanceState);
-
-        getWindow().setFormat(PixelFormat.RGBX_8888); // <--- This makes xperia play happy
-
-        mUnityPlayer = new UnityPlayer(this);
-        setContentView(mUnityPlayer);
-        mUnityPlayer.requestFocus();
-    }
-
-    @Override protected void onNewIntent(Intent intent)
-    {
-        // To support deep linking, we need to make sure that the client can get access to
-        // the last sent intent. The clients access this through a JNI api that allows them
-        // to get the intent set on launch. To update that after launch we have to manually
-        // replace the intent with the one caught here.
-        setIntent(intent);
-    }
-
-    // Quit Unity
-    @Override protected void onDestroy ()
-    {
-        mUnityPlayer.quit();
-        super.onDestroy();
-    }
-
-    // Pause Unity
-    @Override protected void onPause()
-    {
-        super.onPause();
-        mUnityPlayer.pause();
-    }
-
-    // Resume Unity
-    @Override protected void onResume()
-    {
-        super.onResume();
-        mUnityPlayer.resume();
-    }
-
-    // Low Memory Unity
-    @Override public void onLowMemory()
-    {
-        super.onLowMemory();
-        mUnityPlayer.lowMemory();
-    }
-
-    // Trim Memory Unity
-    @Override public void onTrimMemory(int level)
-    {
-        super.onTrimMemory(level);
-        if (level == TRIM_MEMORY_RUNNING_CRITICAL)
-        {
-            mUnityPlayer.lowMemory();
-        }
-    }
-
-    // This ensures the layout will be correct.
-    @Override public void onConfigurationChanged(Configuration newConfig)
-    {
-        super.onConfigurationChanged(newConfig);
-        mUnityPlayer.configurationChanged(newConfig);
-    }
-
-    // Notify Unity of the focus change.
-    @Override public void onWindowFocusChanged(boolean hasFocus)
-    {
-        super.onWindowFocusChanged(hasFocus);
-        mUnityPlayer.windowFocusChanged(hasFocus);
-    }
-
-    // For some reason the multiple keyevent type is not supported by the ndk.
-    // Force event injection by overriding dispatchKeyEvent().
-    @Override public boolean dispatchKeyEvent(KeyEvent event)
-    {
-        if (event.getAction() == KeyEvent.ACTION_MULTIPLE)
-            return mUnityPlayer.injectEvent(event);
-        return super.dispatchKeyEvent(event);
-    }
-
-    // Pass any events not handled by (unfocused) views straight to UnityPlayer
-    @Override public boolean onKeyUp(int keyCode, KeyEvent event)     { return mUnityPlayer.injectEvent(event); }
-    @Override public boolean onKeyDown(int keyCode, KeyEvent event)   { return mUnityPlayer.injectEvent(event); }
-    @Override public boolean onTouchEvent(MotionEvent event)          { return mUnityPlayer.injectEvent(event); }
-    //API12
-    public boolean onGenericMotionEvent(MotionEvent event)  { return mUnityPlayer.injectEvent(event); }
-}
-*/


### PR DESCRIPTION
Removed reference code. Set preview callback to null ensure camera not accessed after release. Use static tag instead of literals on all logs. Remove static methods, construct instance of holder no thread from activity (Un-singletonify). Additional error handling. Added permission check for camera on use.